### PR TITLE
Fix deploy from storybook build to gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,12 @@ script:
   - npm run test
   - npm run report-coverage
   - npm run docs:build
-after_success:
-  - npm run docs:publish
+deploy:
+  provider: pages
+  local-dir: docs
+  github-token: $GH_TOKEN
+  skip-cleanup: true
+  keep-history: true
+  verbose: true
+  on:
+    branch: master


### PR DESCRIPTION
The storybook deploy to gh-pages was failing because travis
did not have the necessary permissions to push to the repository.
This commit adds a new configuration to travis.yml in order
to fix this problem